### PR TITLE
feature/calculate traj point velocities

### DIFF
--- a/cob_script_server/src/simple_script_server/simple_script_server.py
+++ b/cob_script_server/src/simple_script_server/simple_script_server.py
@@ -499,6 +499,10 @@ class simple_script_server:
 
 	## Parse and compose trajectory message
 	def compose_trajectory(self, component_name, parameter_name, speed_factor=1.0, urdf_vel=False, default_vel=None):
+		if urdf_vel and default_vel:
+			rospy.logerr("arguments not valid - cannot set 'urdf_vel' and 'default_vel' at the same time, aborting...")
+			return (JointTrajectory(), 3)
+
 		# get joint_names from parameter server
 		param_string = self.ns_global_prefix + "/" + component_name + "/joint_names"
 		if not rospy.has_param(param_string):

--- a/cob_script_server/src/simple_script_server/simple_script_server.py
+++ b/cob_script_server/src/simple_script_server/simple_script_server.py
@@ -631,7 +631,7 @@ class simple_script_server:
 			try:
 				limit_vel.append(robot_urdf.joint_map[joint_name].limit.velocity)
 			except KeyError:
-				limit_vel.append(default_vel[i])
+				limit_vel.append(default_vel[idx])
 
 		# limit_vel from urdf or default_vel (from argument or parameter server)
 		if urdf_vel:

--- a/cob_script_server/src/simple_script_server/simple_script_server.py
+++ b/cob_script_server/src/simple_script_server/simple_script_server.py
@@ -860,7 +860,7 @@ class simple_script_server:
 	# \param blocking Bool value to specify blocking behaviour.
 	#
 	# # throws error code 3 in case of invalid parameter_name vector
-	def move_rel(self, component_name, parameter_name, blocking=True):
+	def move_rel(self, component_name, parameter_name, blocking=True, speed_factor=1.0, urdf_vel=False, default_vel=None):
 		ah = action_handle("move_rel", component_name, parameter_name, blocking, self.parse)
 		if(self.parse):
 			return ah
@@ -932,7 +932,7 @@ class simple_script_server:
 				return ah
 			end_poses.append(end_pos)
 
-		return self.move_traj(component_name, end_poses, blocking)
+		return self.move_traj(component_name, end_poses, blocking, speed_factor=speed_factor, urdf_vel=urdf_vel, default_vel=default_vel)
 
 #------------------- LED section -------------------#
 	## Set the color of the cob_light component.

--- a/cob_script_server/src/simple_script_server/simple_script_server.py
+++ b/cob_script_server/src/simple_script_server/simple_script_server.py
@@ -659,7 +659,7 @@ class simple_script_server:
 			elif (type(param_acc) is list) and (len(param_acc) == len(start_pos)) and all(((type(item) is float) or (type(item) is int)) for item in param_acc):
 				default_acc = param_acc
 			else:
-				default_acc = numpy.array([0.1 for _ in start_pos]) # rad/s
+				default_acc = numpy.array([1.0 for _ in start_pos]) # rad^2/s
 				rospy.logwarn("parameter %s has wrong format (must be float/int or list of float/int), using default_acc {} [rad^2/sec].".format(param_string,default_acc))
 
 		for point in traj:

--- a/cob_script_server/src/simple_script_server/simple_script_server.py
+++ b/cob_script_server/src/simple_script_server/simple_script_server.py
@@ -643,8 +643,11 @@ class simple_script_server:
 
 		# check velocity limits
 		desired_vel = numpy.array(velocities)*speed_factor
-		if (numpy.any(desired_vel > numpy.array(limit_vel)) or numpy.any(desired_vel < numpy.zeros_like(desired_vel))):
+		if (numpy.any(desired_vel > numpy.array(limit_vel))):
 			rospy.logerr("desired velocities {} exceed velocity limits {},...aborting".format(desired_vel, numpy.array(limit_vel)))
+			return (JointTrajectory(), 3)
+		if (numpy.any(desired_vel <= numpy.zeros_like(desired_vel))):
+			rospy.logerr("desired velocities {} cannot be zero or negative,...aborting".format(desired_vel))
 			return (JointTrajectory(), 3)
 		rospy.loginfo("Velocities are: {}".format(desired_vel))
 

--- a/cob_script_server/src/simple_script_server/simple_script_server.py
+++ b/cob_script_server/src/simple_script_server/simple_script_server.py
@@ -597,29 +597,43 @@ class simple_script_server:
 
 		param_string = self.ns_global_prefix + "/" + component_name + "/default_vel"
 		if not rospy.has_param(param_string):
-			default_vel = 0.1 # rad/s
-			rospy.logwarn("parameter %s does not exist on ROS Parameter Server, using default of %f [rad/sec].",param_string,default_vel)
+			default_vel = numpy.array([0.1 for _ in start_pos]) # rad/s
+			rospy.logwarn("parameter %s does not exist on ROS Parameter Server, using default_vel {} [rad/sec].".format(param_string,default_vel))
 		else:
-			default_vel = rospy.get_param(param_string)
+			param_vel = rospy.get_param(param_string)
+			if (type(param_vel) is float) or (type(param_vel) is int):
+				default_vel = numpy.array([param_vel for _ in start_pos])
+			elif (type(param_vel) is list) and (len(param_vel) == len(start_pos)) and all(((type(item) is float) or (type(item) is int)) for item in param_vel):
+				default_vel = param_vel
+			else:
+				default_vel = numpy.array([0.1 for _ in start_pos]) # rad/s
+				rospy.logwarn("parameter %s has wrong format (must be float/int or list of float/int), using default_vel {} [rad/sec].".format(param_string,default_vel))
 
 		if urdf_vel:
 			robot_urdf = URDF.from_parameter_server()
 			velocities = []
-			for joint_name in joint_names:
+			for idx, joint_name in enumerate(joint_names):
 				try:
 					velocities.append(robot_urdf.joint_map[joint_name].limit.velocity)
 				except KeyError:
-					velocities.append(default_vel)
+					velocities.append(default_vel[i])
 		else:
-			velocities = [default_vel for _ in joint_names]
+			velocities = list(default_vel)
 		rospy.loginfo("Velocities are: {}".format(velocities))
 
 		param_string = self.ns_global_prefix + "/" + component_name + "/default_acc"
 		if not rospy.has_param(param_string):
-			default_acc = 1.0 # rad^2/s
-			rospy.logwarn("parameter %s does not exist on ROS Parameter Server, using default of %f [rad^2/sec].",param_string,default_acc)
+			default_acc = numpy.array([1.0 for _ in start_pos]) # rad^2/s
+			rospy.logwarn("parameter %s does not exist on ROS Parameter Server, using default_acc {} [rad^2/sec].".format(param_string,default_acc))
 		else:
-			default_acc = rospy.get_param(param_string)
+			param_acc = rospy.get_param(param_string)
+			if (type(param_acc) is float) or (type(param_acc) is int):
+				default_acc = numpy.array([param_acc for _ in start_pos])
+			elif (type(param_acc) is list) and (len(param_acc) == len(start_pos)) and all(((type(item) is float) or (type(item) is int)) for item in param_acc):
+				default_acc = param_acc
+			else:
+				default_acc = numpy.array([0.1 for _ in start_pos]) # rad/s
+				rospy.logwarn("parameter %s has wrong format (must be float/int or list of float/int), using default_acc {} [rad^2/sec].".format(param_string,default_acc))
 
 		for point in traj:
 			point_nr = point_nr + 1


### PR DESCRIPTION
implements https://github.com/mojin-robotics/cob4/issues/1277#issuecomment-552875855

this pr (is supposed to) implement the following behavior:
```
sss.move("torso","front") -> current behavior: motion uses `default_vel` from yaml - can be float of list of float
sss.move("torso","front",speed_factor=0.5) -> uses half the speed of `default_vel` from yaml (s.o.)
sss.move("torso","front",speed_factor=2.0) -> uses twice the speed of `default_vel` from yaml (s.o.), but fails in case one joint vel exceeds the respective limit from urdf
sss.move("torso","front",speed_factor=0.0) -> will fail due to zero vel
sss.move("torso","front",speed_factor=-1.0) -> will fail due to negative vel
sss.move("torso","front",urdf_vel=True) -> uses vel limits from urdf
sss.move("torso","front",speed_factor=0.5,urdf_vel=True) -> uses half the vel limits from urdf
sss.move("torso","front",speed_factor=2.0,urdf_vel=True) -> will fail due to exceeding limits
sss.move("torso","front",default_vel=1.0) -> overwrites default_vel from yaml
sss.move("torso","front",default_vel=[n*1.0]) -> overwrites default_vel from yaml
sss.move("torso","front",default_vel=[n!=m*1.0]) -> will fail due to dimension mismatch
sss.move("torso","front",urdf_vel=True,default_vel=1.0) -> will fail due to invalid arguments
```

@LoyVanBeek can you carefully review (you could do it commit-by-commit), test and merge this into your feature branch?

@floweisshardt and @fmessmer will then test final version of https://github.com/ipa320/cob_command_tools/pull/259 on hw again